### PR TITLE
Remove obsolete Yosys flags

### DIFF
--- a/blinky.ys
+++ b/blinky.ys
@@ -1,2 +1,2 @@
 read_verilog blinky.v
-synth_ecp5 -noccu2 -nomux -nodram -json blinky.json
+synth_ecp5 -json blinky.json


### PR DESCRIPTION
Remove obsolete Yosys flags. Since there is likelihood of this project being used as a template for larger projects, these flags can have severe detrimental effect on timing performance (-30% fmax in my experience).

According to https://gitter.im/ulx3s/Lobby?at=5c038a32bc1a693e3a4222d9, the flags were necessary at some point, but that time is long gone.